### PR TITLE
feat: add auto re-register when instance deleted from Polaris

### DIFF
--- a/bootstrap/registry.go
+++ b/bootstrap/registry.go
@@ -21,7 +21,7 @@ import (
 	"context"
 	"fmt"
 	"math"
-	"math/rand"
+	mrand "math/rand/v2"
 	"net"
 	"sync/atomic"
 	"time"
@@ -55,23 +55,38 @@ const (
 
 var rid uint64
 
+// 初始化后只读，不参与并发写
 var (
-	registerInstances []*polaris.Instance
-
 	polarisServerAddress string
 	polarisToken         string
-
-	// 重注册所需的上下文（首次注册时保存）
-	savedRegistryCfg      *Registry
-	savedAPIServers       []apiserver.APIServer
-	savedAPIServerConfigs []apiserver.Config
-	savedServerAddress    string
-
-	// 重注册状态（使用 atomic 操作保证并发安全）
-	notFoundCount   int32 // NOT_FOUND 连续失败次数
-	reRegisterCount int32 // 重注册重试计数（用于指数退避）
-	reRegistering   int32 // 0/1 标志，是否正在执行重注册
 )
+
+// registryCtx 保存首次 selfRegister 时的参数，供重注册复用。
+// 通过 atomic.Pointer 整体替换，避免字段粒度的竞争。
+type registryCtx struct {
+	cfg              *Registry
+	servers          []apiserver.APIServer
+	apiServerConfigs []apiserver.Config
+	serverAddress    string
+}
+
+// registrar 管理注册状态与重注册流程；所有字段用 atomic 原语保护。
+type registrar struct {
+	ctx       atomic.Pointer[registryCtx]
+	instances atomic.Pointer[[]*polaris.Instance]
+
+	notFoundCount   atomic.Int32 // 心跳连续 NOT_FOUND 次数
+	reRegisterCount atomic.Int32 // 重注册重试计数（用于指数退避）
+	reRegistering   atomic.Int32 // 0/1 标志，是否正在执行重注册
+}
+
+var reg = &registrar{}
+
+// registerFn 是 doSelfRegister 的注入点，便于单测替换。
+var registerFn = func(r *registrar, cfg *Registry, servers []apiserver.APIServer,
+	apiServerConfigs []apiserver.Config, serverAddress string) error {
+	return r.doSelfRegister(cfg, servers, apiServerConfigs, serverAddress)
+}
 
 // 初始化客户端SDK
 func initPolarisClient(registryCfg *Registry) (err error) {
@@ -94,37 +109,18 @@ func startHeartbeat(ctx context.Context) {
 				log.Infof("[Bootstrap] heartbeat routine stopped")
 				return
 			case <-ticker.C:
-				if len(registerInstances) == 0 {
+				snapshot := reg.loadInstances()
+				if len(snapshot) == 0 {
 					continue
 				}
 				_ = doWithPolarisClient(func(client polaris.PolarisGRPCClient) error {
-					for _, instance := range registerInstances {
+					for _, instance := range snapshot {
 						instance := instance
-						heartbeat := func() error {
-							reqId := fmt.Sprintf("%s_%d", instance.GetService().GetValue(), atomic.AddUint64(&rid, 1))
-							clientCtx, cancel := CreateHeaderContextWithReqId(timeout, reqId)
-							defer cancel()
-							resp, err := client.Heartbeat(clientCtx, instance)
-							if nil != err {
-								log.Errorf("[Bootstrap] fail to send heartbeat, err is %v", err)
-								return err
-							}
-							// 检查响应码，判断是否为 NOT_FOUND
-							code := resp.GetCode().GetValue()
-							if code == notFoundResourceCode {
-								cnt := atomic.AddInt32(&notFoundCount, 1)
-								log.Errorf("[Bootstrap] heartbeat response not found for instance %s:%d, notFoundCount: %d",
-									instance.GetHost().GetValue(), instance.GetPort().GetValue(), cnt)
-								if cnt > int32(maxHeartbeatFailCount) {
-									triggerAsyncReRegister(ctx)
-								}
-								return fmt.Errorf("instance not found")
-							}
-							// 心跳成功，重置失败计数
-							atomic.StoreInt32(&notFoundCount, 0)
-							return nil
-						}
-						if err := heartbeat(); nil != err {
+						reqId := fmt.Sprintf("%s_%d", instance.GetService().GetValue(), atomic.AddUint64(&rid, 1))
+						clientCtx, cancel := CreateHeaderContextWithReqId(timeout, reqId)
+						resp, err := client.Heartbeat(clientCtx, instance)
+						cancel()
+						if err := reg.handleHeartbeatResp(ctx, instance, resp, err); err != nil {
 							return err
 						}
 					}
@@ -135,63 +131,95 @@ func startHeartbeat(ctx context.Context) {
 	}()
 }
 
-// triggerAsyncReRegister 触发异步重注册，使用 CAS 防止并发
-func triggerAsyncReRegister(ctx context.Context) {
-	if !atomic.CompareAndSwapInt32(&reRegistering, 0, 1) {
+// loadInstances 返回已注册实例的快照；nil 时返回空切片。
+func (r *registrar) loadInstances() []*polaris.Instance {
+	p := r.instances.Load()
+	if p == nil {
+		return nil
+	}
+	return *p
+}
+
+// handleHeartbeatResp 处理单次心跳响应；返回 error 表示心跳失败，上层终止本轮。
+// 连续 NOT_FOUND 超阈值时触发异步重注册。
+func (r *registrar) handleHeartbeatResp(ctx context.Context, instance *polaris.Instance,
+	resp *polaris.Response, err error) error {
+	if err != nil {
+		log.Errorf("[Bootstrap] fail to send heartbeat, err is %v", err)
+		return err
+	}
+	if resp.GetCode().GetValue() == notFoundResourceCode {
+		cnt := r.notFoundCount.Add(1)
+		log.Errorf("[Bootstrap] heartbeat response not found for instance %s:%d, notFoundCount: %d",
+			instance.GetHost().GetValue(), instance.GetPort().GetValue(), cnt)
+		if cnt > int32(maxHeartbeatFailCount) {
+			r.triggerAsyncReRegister(ctx)
+		}
+		return fmt.Errorf("instance not found")
+	}
+	r.notFoundCount.Store(0)
+	return nil
+}
+
+// triggerAsyncReRegister 触发异步重注册，使用 CAS 防止并发。
+func (r *registrar) triggerAsyncReRegister(ctx context.Context) {
+	if !r.reRegistering.CompareAndSwap(0, 1) {
 		log.Infof("[Bootstrap] re-register already in progress, skip")
 		return
 	}
-	go asyncReRegister(ctx)
+	go r.asyncReRegister(ctx)
 }
 
-// asyncReRegister 异步执行重注册，带指数退避 + 随机抖动
-func asyncReRegister(ctx context.Context) {
-	defer atomic.StoreInt32(&reRegistering, 0)
+// asyncReRegister 异步执行重注册，内部循环重试。
+// 每轮按 reRegisterCount 计算退避延迟；成功后重置计数器。
+func (r *registrar) asyncReRegister(ctx context.Context) {
+	defer r.reRegistering.Store(0)
 
-	count := atomic.LoadInt32(&reRegisterCount)
-	delay := calcReRegisterDelay(count)
-
-	log.Infof("[Bootstrap] triggering async re-register, reRegisterCount: %d, delay: %v", count, delay)
-
-	// 等待退避时间，同时监听 ctx 取消
-	if delay > 0 {
-		timer := time.NewTimer(delay)
-		defer timer.Stop()
-		select {
-		case <-ctx.Done():
-			log.Infof("[Bootstrap] re-register cancelled due to context done")
-			return
-		case <-timer.C:
+	for {
+		count := r.reRegisterCount.Load()
+		if delay := calcReRegisterDelay(count); delay > 0 {
+			log.Infof("[Bootstrap] re-register backoff, reRegisterCount: %d, delay: %v", count, delay)
+			timer := time.NewTimer(delay)
+			select {
+			case <-ctx.Done():
+				timer.Stop()
+				log.Infof("[Bootstrap] re-register cancelled due to context done")
+				return
+			case <-timer.C:
+			}
 		}
-	}
 
-	// 执行重注册
-	if savedRegistryCfg == nil {
-		log.Errorf("[Bootstrap] re-register failed: saved registry config is nil")
+		saved := r.ctx.Load()
+		if saved == nil {
+			log.Errorf("[Bootstrap] re-register failed: saved registry config is nil")
+			return
+		}
+
+		if err := registerFn(r, saved.cfg, saved.servers, saved.apiServerConfigs, saved.serverAddress); err != nil {
+			r.reRegisterCount.Add(1)
+			log.Errorf("[Bootstrap] re-register failed, err: %s", err.Error())
+			if ctx.Err() != nil {
+				return
+			}
+			continue
+		}
+
+		log.Infof("[Bootstrap] re-register success")
+		r.notFoundCount.Store(0)
+		r.reRegisterCount.Store(0)
 		return
 	}
-
-	if err := selfRegister(savedRegistryCfg, savedAPIServers, savedAPIServerConfigs, savedServerAddress); err != nil {
-		atomic.AddInt32(&reRegisterCount, 1)
-		log.Errorf("[Bootstrap] re-register failed, err: %s", err.Error())
-		return
-	}
-
-	// 重注册成功，重置所有计数器
-	log.Infof("[Bootstrap] re-register success")
-	atomic.StoreInt32(&notFoundCount, 0)
-	atomic.StoreInt32(&reRegisterCount, 0)
 }
 
-// calcReRegisterDelay 计算重注册退避延迟
-// delay = min(serverTtl * 2^(count-1) + random(serverTtl), maxReRegisterDelay)
-// 首次触发（count=0）delay=0，立即重注册
+// calcReRegisterDelay 计算重注册退避延迟。
+// delay = min(serverTtl * 2^(count-1) + random(serverTtl), maxReRegisterDelay)；
+// 首次触发（count=0）delay=0，立即重注册。
 func calcReRegisterDelay(count int32) time.Duration {
 	if count <= 0 {
 		return 0
 	}
 	base := float64(serverTtl) * math.Pow(2, float64(count-1))
-	jitter := float64(rand.Int63n(int64(serverTtl)))
+	jitter := float64(mrand.Int64N(int64(serverTtl)))
 	delay := time.Duration(base + jitter)
 	return min(delay, maxReRegisterDelay)
 }
@@ -254,19 +282,25 @@ func CreateHeaderContextWithReqId(timeout time.Duration, reqID string) (context.
 
 // 注册限流Server
 func selfRegister(cfg *Registry, servers []apiserver.APIServer, apiServerConfigs []apiserver.Config, serverAddress string) error {
-	// 保存注册上下文，供重注册使用
-	savedRegistryCfg = cfg
-	savedAPIServers = servers
-	savedAPIServerConfigs = apiServerConfigs
-	savedServerAddress = serverAddress
+	reg.ctx.Store(&registryCtx{
+		cfg:              cfg,
+		servers:          servers,
+		apiServerConfigs: apiServerConfigs,
+		serverAddress:    serverAddress,
+	})
+	return registerFn(reg, cfg, servers, apiServerConfigs, serverAddress)
+}
 
+// doSelfRegister 执行真正的注册操作，成功后把 heartbeat instance 列表写回 registrar。
+func (r *registrar) doSelfRegister(cfg *Registry, servers []apiserver.APIServer,
+	apiServerConfigs []apiserver.Config, serverAddress string) error {
 	// 构建 server name -> apiserver.Config 的映射
 	serverCfgMap := make(map[string]apiserver.Config, len(apiServerConfigs))
 	for _, sc := range apiServerConfigs {
 		serverCfgMap[sc.Name] = sc
 	}
 	// 开始对每个监听端口的服务进行注册
-	var instances = make([]*polaris.Instance, 0, len(servers))
+	instances := make([]*polaris.Instance, 0, len(servers))
 	for _, server := range servers {
 		serverCfg := serverCfgMap[server.GetProtocol()]
 		// 检查是否需要注册，不需要注册的 server 跳过
@@ -277,65 +311,58 @@ func selfRegister(cfg *Registry, servers []apiserver.APIServer, apiServerConfigs
 		instance := buildRegisterRequest(cfg, server, serverCfg, serverAddress)
 		instances = append(instances, instance)
 	}
-	var heartbeatInstances = make([]*polaris.Instance, 0, len(servers))
+	heartbeatInstances := make([]*polaris.Instance, 0, len(instances))
 	err := doWithPolarisClient(func(client polaris.PolarisGRPCClient) error {
 		for _, instance := range instances {
 			instance := instance
-			register := func() error {
-				reqId := fmt.Sprintf("%s_%d", instance.GetService().GetValue(), atomic.AddUint64(&rid, 1))
-				clientCtx, cancel := CreateHeaderContextWithReqId(timeout, reqId)
-				defer cancel()
-				resp, err := client.RegisterInstance(clientCtx, instance)
-				if nil != err {
-					log.Errorf("[Bootstrap] fail to register instance %s:%d, err: %s", instance.GetHost().GetValue(), instance.GetPort().GetValue(), err)
-					return err
-				}
-				log.Infof("[Bootstrap] instance %s:%d registered, code %d", instance.GetHost().GetValue(), instance.GetPort().GetValue(), resp.GetCode().GetValue())
-				hbInstance := &polaris.Instance{
-					Id:           &wrappers.StringValue{Value: resp.GetInstance().GetId().GetValue()},
-					Namespace:    instance.GetNamespace(),
-					Service:      instance.GetService(),
-					Host:         instance.GetHost(),
-					Port:         instance.GetPort(),
-					ServiceToken: instance.GetServiceToken(),
-				}
-				heartbeatInstances = append(heartbeatInstances, hbInstance)
-				return nil
-			}
-			if err := register(); nil != err {
+			reqId := fmt.Sprintf("%s_%d", instance.GetService().GetValue(), atomic.AddUint64(&rid, 1))
+			clientCtx, cancel := CreateHeaderContextWithReqId(timeout, reqId)
+			resp, err := client.RegisterInstance(clientCtx, instance)
+			cancel()
+			if err != nil {
+				log.Errorf("[Bootstrap] fail to register instance %s:%d, err: %s",
+					instance.GetHost().GetValue(), instance.GetPort().GetValue(), err)
 				return err
 			}
+			log.Infof("[Bootstrap] instance %s:%d registered, code %d",
+				instance.GetHost().GetValue(), instance.GetPort().GetValue(), resp.GetCode().GetValue())
+			heartbeatInstances = append(heartbeatInstances, &polaris.Instance{
+				Id:           &wrappers.StringValue{Value: resp.GetInstance().GetId().GetValue()},
+				Namespace:    instance.GetNamespace(),
+				Service:      instance.GetService(),
+				Host:         instance.GetHost(),
+				Port:         instance.GetPort(),
+				ServiceToken: instance.GetServiceToken(),
+			})
 		}
 		return nil
 	})
-	if nil != err {
+	if err != nil {
 		return err
 	}
-	registerInstances = heartbeatInstances
+	r.instances.Store(&heartbeatInstances)
 	return nil
 }
 
 // 反注册
 func selfDeregister() error {
-	if len(registerInstances) == 0 {
+	snapshot := reg.loadInstances()
+	if len(snapshot) == 0 {
 		return nil
 	}
 	return doWithPolarisClient(func(client polaris.PolarisGRPCClient) error {
-		for _, instance := range registerInstances {
+		for _, instance := range snapshot {
 			instance := instance
-			deregister := func() error {
-				reqId := fmt.Sprintf("%s_%d", instance.GetService().GetValue(), atomic.AddUint64(&rid, 1))
-				clientCtx, cancel := CreateHeaderContextWithReqId(timeout, reqId)
-				defer cancel()
-				resp, err := client.DeregisterInstance(clientCtx, instance)
-				if err != nil {
-					log.Errorf("[Bootstrap] fail to deregister instance err: %s", err.Error())
-					return err
-				}
-				log.Infof("[Bootstrap] success to deregister instance %s:%d, code %d", instance.GetHost().GetValue(), instance.GetPort().GetValue(), resp.GetCode().GetValue())
-				return nil
+			reqId := fmt.Sprintf("%s_%d", instance.GetService().GetValue(), atomic.AddUint64(&rid, 1))
+			clientCtx, cancel := CreateHeaderContextWithReqId(timeout, reqId)
+			resp, err := client.DeregisterInstance(clientCtx, instance)
+			cancel()
+			if err != nil {
+				log.Errorf("[Bootstrap] fail to deregister instance err: %s", err.Error())
+				continue
 			}
-			_ = deregister()
+			log.Infof("[Bootstrap] success to deregister instance %s:%d, code %d",
+				instance.GetHost().GetValue(), instance.GetPort().GetValue(), resp.GetCode().GetValue())
 		}
 		return nil
 	})

--- a/bootstrap/registry.go
+++ b/bootstrap/registry.go
@@ -162,6 +162,8 @@ func (r *registrar) handleHeartbeatResp(ctx context.Context, instance *polaris.I
 }
 
 // triggerAsyncReRegister 触发异步重注册，使用 CAS 防止并发。
+// asyncReRegister 必须由本函数作为唯一入口调起，否则其 defer 中的
+// reRegistering.Store(0) 会与未配对的 CAS 造成状态错乱。
 func (r *registrar) triggerAsyncReRegister(ctx context.Context) {
 	if !r.reRegistering.CompareAndSwap(0, 1) {
 		log.Infof("[Bootstrap] re-register already in progress, skip")
@@ -172,6 +174,9 @@ func (r *registrar) triggerAsyncReRegister(ctx context.Context) {
 
 // asyncReRegister 异步执行重注册，内部循环重试。
 // 每轮按 reRegisterCount 计算退避延迟；成功后重置计数器。
+//
+// 注意：必须在 reRegistering == 1 的前提下调用（即由 triggerAsyncReRegister
+// 唯一入口触发，或测试中显式 Store(1) 后直接调用）；defer 中会 Store(0)。
 func (r *registrar) asyncReRegister(ctx context.Context) {
 	defer r.reRegistering.Store(0)
 
@@ -218,10 +223,19 @@ func calcReRegisterDelay(count int32) time.Duration {
 	if count <= 0 {
 		return 0
 	}
+	// 提前截断大指数：count=5 时 base 已经是 80s（> 60s 上限），
+	// 继续累加只会在 float64 → int64 转换时溢出。
+	const maxExp = 10
+	if count > maxExp {
+		return maxReRegisterDelay
+	}
 	base := float64(serverTtl) * math.Pow(2, float64(count-1))
 	jitter := float64(mrand.Int64N(int64(serverTtl)))
 	delay := time.Duration(base + jitter)
-	return min(delay, maxReRegisterDelay)
+	if delay < 0 || delay > maxReRegisterDelay {
+		return maxReRegisterDelay
+	}
+	return delay
 }
 
 func doWithPolarisClient(handle func(polaris.PolarisGRPCClient) error) error {

--- a/bootstrap/registry.go
+++ b/bootstrap/registry.go
@@ -83,12 +83,17 @@ type registrar struct {
 var reg = &registrar{}
 
 // registerFn 是 doSelfRegister 的注入点，便于单测替换。
-var registerFn = func(r *registrar, cfg *Registry, servers []apiserver.APIServer,
-	apiServerConfigs []apiserver.Config, serverAddress string) error {
-	return r.doSelfRegister(cfg, servers, apiServerConfigs, serverAddress)
+// 调用前 r.ctx 必须已由 selfRegister 写入。
+var registerFn = func(r *registrar) error {
+	return r.doSelfRegister()
 }
 
-// 初始化客户端SDK
+// nextReqID 基于服务名 + 单调递增计数生成请求跟踪 ID。
+func nextReqID(instance *polaris.Instance) string {
+	return fmt.Sprintf("%s_%d", instance.GetService().GetValue(), atomic.AddUint64(&rid, 1))
+}
+
+// initPolarisClient 初始化 Polaris 客户端地址与 token（启动期调用，后续只读）。
 func initPolarisClient(registryCfg *Registry) (err error) {
 	polarisServerAddress = registryCfg.PolarisServerAddress
 	polarisToken = registryCfg.Token
@@ -98,7 +103,6 @@ func initPolarisClient(registryCfg *Registry) (err error) {
 	return nil
 }
 
-// 启动心跳上报
 func startHeartbeat(ctx context.Context) {
 	go func() {
 		ticker := time.NewTicker(serverTtl)
@@ -116,8 +120,7 @@ func startHeartbeat(ctx context.Context) {
 				_ = doWithPolarisClient(func(client polaris.PolarisGRPCClient) error {
 					for _, instance := range snapshot {
 						instance := instance
-						reqId := fmt.Sprintf("%s_%d", instance.GetService().GetValue(), atomic.AddUint64(&rid, 1))
-						clientCtx, cancel := CreateHeaderContextWithReqId(timeout, reqId)
+						clientCtx, cancel := CreateHeaderContextWithReqId(timeout, nextReqID(instance))
 						resp, err := client.Heartbeat(clientCtx, instance)
 						cancel()
 						if err := reg.handleHeartbeatResp(ctx, instance, resp, err); err != nil {
@@ -194,13 +197,12 @@ func (r *registrar) asyncReRegister(ctx context.Context) {
 			}
 		}
 
-		saved := r.ctx.Load()
-		if saved == nil {
+		if r.ctx.Load() == nil {
 			log.Errorf("[Bootstrap] re-register failed: saved registry config is nil")
 			return
 		}
 
-		if err := registerFn(r, saved.cfg, saved.servers, saved.apiServerConfigs, saved.serverAddress); err != nil {
+		if err := registerFn(r); err != nil {
 			r.reRegisterCount.Add(1)
 			log.Errorf("[Bootstrap] re-register failed, err: %s", err.Error())
 			if ctx.Err() != nil {
@@ -254,7 +256,6 @@ func doWithPolarisClient(handle func(polaris.PolarisGRPCClient) error) error {
 	return handle(client)
 }
 
-// 创建服务注册请求
 func buildRegisterRequest(cfg *Registry, server apiserver.APIServer, serverCfg apiserver.Config, serverAddress string) *polaris.Instance {
 	instance := &polaris.Instance{}
 	instance.Namespace = &wrappers.StringValue{Value: cfg.Namespace}
@@ -294,7 +295,6 @@ func CreateHeaderContextWithReqId(timeout time.Duration, reqID string) (context.
 	return metadata.NewOutgoingContext(ctx, md), cancel
 }
 
-// 注册限流Server
 func selfRegister(cfg *Registry, servers []apiserver.APIServer, apiServerConfigs []apiserver.Config, serverAddress string) error {
 	reg.ctx.Store(&registryCtx{
 		cfg:              cfg,
@@ -302,22 +302,26 @@ func selfRegister(cfg *Registry, servers []apiserver.APIServer, apiServerConfigs
 		apiServerConfigs: apiServerConfigs,
 		serverAddress:    serverAddress,
 	})
-	return registerFn(reg, cfg, servers, apiServerConfigs, serverAddress)
+	return registerFn(reg)
 }
 
 // doSelfRegister 执行真正的注册操作，成功后把 heartbeat instance 列表写回 registrar。
-func (r *registrar) doSelfRegister(cfg *Registry, servers []apiserver.APIServer,
-	apiServerConfigs []apiserver.Config, serverAddress string) error {
-	// 构建 server name -> apiserver.Config 的映射
+// 调用前必须已将 registryCtx 写入 r.ctx。
+func (r *registrar) doSelfRegister() error {
+	saved := r.ctx.Load()
+	if saved == nil {
+		return fmt.Errorf("registry context not initialized")
+	}
+	cfg, servers, apiServerConfigs, serverAddress :=
+		saved.cfg, saved.servers, saved.apiServerConfigs, saved.serverAddress
+
 	serverCfgMap := make(map[string]apiserver.Config, len(apiServerConfigs))
 	for _, sc := range apiServerConfigs {
 		serverCfgMap[sc.Name] = sc
 	}
-	// 开始对每个监听端口的服务进行注册
 	instances := make([]*polaris.Instance, 0, len(servers))
 	for _, server := range servers {
 		serverCfg := serverCfgMap[server.GetProtocol()]
-		// 检查是否需要注册，不需要注册的 server 跳过
 		if !serverCfg.ShouldRegister() {
 			log.Infof("[Bootstrap] api server(%s) register is disabled, skip registration", server.GetProtocol())
 			continue
@@ -329,8 +333,7 @@ func (r *registrar) doSelfRegister(cfg *Registry, servers []apiserver.APIServer,
 	err := doWithPolarisClient(func(client polaris.PolarisGRPCClient) error {
 		for _, instance := range instances {
 			instance := instance
-			reqId := fmt.Sprintf("%s_%d", instance.GetService().GetValue(), atomic.AddUint64(&rid, 1))
-			clientCtx, cancel := CreateHeaderContextWithReqId(timeout, reqId)
+			clientCtx, cancel := CreateHeaderContextWithReqId(timeout, nextReqID(instance))
 			resp, err := client.RegisterInstance(clientCtx, instance)
 			cancel()
 			if err != nil {
@@ -358,7 +361,6 @@ func (r *registrar) doSelfRegister(cfg *Registry, servers []apiserver.APIServer,
 	return nil
 }
 
-// 反注册
 func selfDeregister() error {
 	snapshot := reg.loadInstances()
 	if len(snapshot) == 0 {
@@ -367,8 +369,7 @@ func selfDeregister() error {
 	return doWithPolarisClient(func(client polaris.PolarisGRPCClient) error {
 		for _, instance := range snapshot {
 			instance := instance
-			reqId := fmt.Sprintf("%s_%d", instance.GetService().GetValue(), atomic.AddUint64(&rid, 1))
-			clientCtx, cancel := CreateHeaderContextWithReqId(timeout, reqId)
+			clientCtx, cancel := CreateHeaderContextWithReqId(timeout, nextReqID(instance))
 			resp, err := client.DeregisterInstance(clientCtx, instance)
 			cancel()
 			if err != nil {

--- a/bootstrap/registry.go
+++ b/bootstrap/registry.go
@@ -20,6 +20,8 @@ package bootstrap
 import (
 	"context"
 	"fmt"
+	"math"
+	"math/rand"
 	"net"
 	"sync/atomic"
 	"time"
@@ -42,6 +44,13 @@ const (
 	headerRequestID = "request-id"
 
 	timeout = 1 * time.Second
+
+	// 心跳返回 NOT_FOUND 连续失败阈值，超过后触发重注册
+	maxHeartbeatFailCount = 2
+	// 重注册退避上限
+	maxReRegisterDelay = 60 * time.Second
+	// Polaris NotFoundResource 错误码
+	notFoundResourceCode uint32 = 400202
 )
 
 var rid uint64
@@ -51,6 +60,17 @@ var (
 
 	polarisServerAddress string
 	polarisToken         string
+
+	// 重注册所需的上下文（首次注册时保存）
+	savedRegistryCfg      *Registry
+	savedAPIServers       []apiserver.APIServer
+	savedAPIServerConfigs []apiserver.Config
+	savedServerAddress    string
+
+	// 重注册状态（使用 atomic 操作保证并发安全）
+	notFoundCount   int32 // NOT_FOUND 连续失败次数
+	reRegisterCount int32 // 重注册重试计数（用于指数退避）
+	reRegistering   int32 // 0/1 标志，是否正在执行重注册
 )
 
 // 初始化客户端SDK
@@ -84,11 +104,25 @@ func startHeartbeat(ctx context.Context) {
 							reqId := fmt.Sprintf("%s_%d", instance.GetService().GetValue(), atomic.AddUint64(&rid, 1))
 							clientCtx, cancel := CreateHeaderContextWithReqId(timeout, reqId)
 							defer cancel()
-							_, err := client.Heartbeat(clientCtx, instance)
+							resp, err := client.Heartbeat(clientCtx, instance)
 							if nil != err {
-								log.Errorf("[Bootstrap] fail to send heatBeat, err is %v", err)
+								log.Errorf("[Bootstrap] fail to send heartbeat, err is %v", err)
+								return err
 							}
-							return err
+							// 检查响应码，判断是否为 NOT_FOUND
+							code := resp.GetCode().GetValue()
+							if code == notFoundResourceCode {
+								cnt := atomic.AddInt32(&notFoundCount, 1)
+								log.Errorf("[Bootstrap] heartbeat response not found for instance %s:%d, notFoundCount: %d",
+									instance.GetHost().GetValue(), instance.GetPort().GetValue(), cnt)
+								if cnt > int32(maxHeartbeatFailCount) {
+									triggerAsyncReRegister(ctx)
+								}
+								return fmt.Errorf("instance not found")
+							}
+							// 心跳成功，重置失败计数
+							atomic.StoreInt32(&notFoundCount, 0)
+							return nil
 						}
 						if err := heartbeat(); nil != err {
 							return err
@@ -99,6 +133,67 @@ func startHeartbeat(ctx context.Context) {
 			}
 		}
 	}()
+}
+
+// triggerAsyncReRegister 触发异步重注册，使用 CAS 防止并发
+func triggerAsyncReRegister(ctx context.Context) {
+	if !atomic.CompareAndSwapInt32(&reRegistering, 0, 1) {
+		log.Infof("[Bootstrap] re-register already in progress, skip")
+		return
+	}
+	go asyncReRegister(ctx)
+}
+
+// asyncReRegister 异步执行重注册，带指数退避 + 随机抖动
+func asyncReRegister(ctx context.Context) {
+	defer atomic.StoreInt32(&reRegistering, 0)
+
+	count := atomic.LoadInt32(&reRegisterCount)
+	delay := calcReRegisterDelay(count)
+
+	log.Infof("[Bootstrap] triggering async re-register, reRegisterCount: %d, delay: %v", count, delay)
+
+	// 等待退避时间，同时监听 ctx 取消
+	if delay > 0 {
+		timer := time.NewTimer(delay)
+		defer timer.Stop()
+		select {
+		case <-ctx.Done():
+			log.Infof("[Bootstrap] re-register cancelled due to context done")
+			return
+		case <-timer.C:
+		}
+	}
+
+	// 执行重注册
+	if savedRegistryCfg == nil {
+		log.Errorf("[Bootstrap] re-register failed: saved registry config is nil")
+		return
+	}
+
+	if err := selfRegister(savedRegistryCfg, savedAPIServers, savedAPIServerConfigs, savedServerAddress); err != nil {
+		atomic.AddInt32(&reRegisterCount, 1)
+		log.Errorf("[Bootstrap] re-register failed, err: %s", err.Error())
+		return
+	}
+
+	// 重注册成功，重置所有计数器
+	log.Infof("[Bootstrap] re-register success")
+	atomic.StoreInt32(&notFoundCount, 0)
+	atomic.StoreInt32(&reRegisterCount, 0)
+}
+
+// calcReRegisterDelay 计算重注册退避延迟
+// delay = min(serverTtl * 2^(count-1) + random(serverTtl), maxReRegisterDelay)
+// 首次触发（count=0）delay=0，立即重注册
+func calcReRegisterDelay(count int32) time.Duration {
+	if count <= 0 {
+		return 0
+	}
+	base := float64(serverTtl) * math.Pow(2, float64(count-1))
+	jitter := float64(rand.Int63n(int64(serverTtl)))
+	delay := time.Duration(base + jitter)
+	return min(delay, maxReRegisterDelay)
 }
 
 func doWithPolarisClient(handle func(polaris.PolarisGRPCClient) error) error {
@@ -159,6 +254,12 @@ func CreateHeaderContextWithReqId(timeout time.Duration, reqID string) (context.
 
 // 注册限流Server
 func selfRegister(cfg *Registry, servers []apiserver.APIServer, apiServerConfigs []apiserver.Config, serverAddress string) error {
+	// 保存注册上下文，供重注册使用
+	savedRegistryCfg = cfg
+	savedAPIServers = servers
+	savedAPIServerConfigs = apiServerConfigs
+	savedServerAddress = serverAddress
+
 	// 构建 server name -> apiserver.Config 的映射
 	serverCfgMap := make(map[string]apiserver.Config, len(apiServerConfigs))
 	for _, sc := range apiServerConfigs {
@@ -186,7 +287,7 @@ func selfRegister(cfg *Registry, servers []apiserver.APIServer, apiServerConfigs
 				defer cancel()
 				resp, err := client.RegisterInstance(clientCtx, instance)
 				if nil != err {
-					log.Infof("[Bootstrap] fail to register instance %s:%d, err: %s", instance.GetHost().GetValue(), instance.GetPort().GetValue(), err)
+					log.Errorf("[Bootstrap] fail to register instance %s:%d, err: %s", instance.GetHost().GetValue(), instance.GetPort().GetValue(), err)
 					return err
 				}
 				log.Infof("[Bootstrap] instance %s:%d registered, code %d", instance.GetHost().GetValue(), instance.GetPort().GetValue(), resp.GetCode().GetValue())
@@ -201,9 +302,8 @@ func selfRegister(cfg *Registry, servers []apiserver.APIServer, apiServerConfigs
 				heartbeatInstances = append(heartbeatInstances, hbInstance)
 				return nil
 			}
-			err := register()
-			if nil != err {
-				return nil
+			if err := register(); nil != err {
+				return err
 			}
 		}
 		return nil

--- a/bootstrap/registry_test.go
+++ b/bootstrap/registry_test.go
@@ -672,6 +672,15 @@ func TestCalcReRegisterDelay(t *testing.T) {
 		Convey("大 count 值时 delay 应不超过 maxReRegisterDelay", func() {
 			delay := calcReRegisterDelay(100)
 			So(delay, ShouldBeLessThanOrEqualTo, maxReRegisterDelay)
+			So(delay, ShouldBeGreaterThan, time.Duration(0))
+		})
+
+		Convey("math.MaxInt32 级 count 不应产生负数或溢出值", func() {
+			// 覆盖长期重试场景：避免 math.Pow 结果 +Inf -> int64 溢出为负数
+			for _, c := range []int32{11, 20, 100, 1000, 1 << 20, 1<<31 - 1} {
+				delay := calcReRegisterDelay(c)
+				So(delay, ShouldEqual, maxReRegisterDelay)
+			}
 		})
 	})
 }

--- a/bootstrap/registry_test.go
+++ b/bootstrap/registry_test.go
@@ -19,15 +19,18 @@ package bootstrap
 
 import (
 	"context"
+	"fmt"
 	"os"
 	"sync/atomic"
 	"testing"
 	"time"
 
+	"github.com/golang/protobuf/ptypes/wrappers"
 	. "github.com/smartystreets/goconvey/convey"
 	"gopkg.in/yaml.v2"
 
 	"github.com/polarismesh/polaris-limiter/apiserver"
+	polaris "github.com/polarismesh/polaris-limiter/pkg/api/polaris/v1"
 )
 
 // mockAPIServer 模拟 APIServer 接口，用于单测
@@ -628,15 +631,13 @@ api-servers:
 	})
 }
 
-// resetReRegisterState 重置所有重注册相关的全局状态，用于测试隔离
-func resetReRegisterState() {
-	atomic.StoreInt32(&notFoundCount, 0)
-	atomic.StoreInt32(&reRegisterCount, 0)
-	atomic.StoreInt32(&reRegistering, 0)
-	savedRegistryCfg = nil
-	savedAPIServers = nil
-	savedAPIServerConfigs = nil
-	savedServerAddress = ""
+// resetRegistrar 重置 registrar 单例及 registerFn 注入点，供测试隔离使用。
+func resetRegistrar() {
+	reg = &registrar{}
+	registerFn = func(r *registrar, cfg *Registry, servers []apiserver.APIServer,
+		apiServerConfigs []apiserver.Config, serverAddress string) error {
+		return r.doSelfRegister(cfg, servers, apiServerConfigs, serverAddress)
+	}
 }
 
 // TestCalcReRegisterDelay 测试退避延迟计算逻辑
@@ -675,144 +676,233 @@ func TestCalcReRegisterDelay(t *testing.T) {
 	})
 }
 
-// TestReRegisterState_AtomicFlags 测试重注册状态标志的原子操作
-func TestReRegisterState_AtomicFlags(t *testing.T) {
-	Convey("测试重注册状态标志", t, func() {
-		defer resetReRegisterState()
-
-		Convey("初始状态 reRegistering 应为 0", func() {
-			resetReRegisterState()
-			So(atomic.LoadInt32(&reRegistering), ShouldEqual, 0)
-		})
-
-		Convey("CAS 设置 reRegistering 应成功", func() {
-			resetReRegisterState()
-			ok := atomic.CompareAndSwapInt32(&reRegistering, 0, 1)
-			So(ok, ShouldBeTrue)
-			So(atomic.LoadInt32(&reRegistering), ShouldEqual, 1)
-		})
-
-		Convey("reRegistering 已为 1 时 CAS 应失败", func() {
-			resetReRegisterState()
-			atomic.StoreInt32(&reRegistering, 1)
-			ok := atomic.CompareAndSwapInt32(&reRegistering, 0, 1)
-			So(ok, ShouldBeFalse)
-		})
-
-		Convey("notFoundCount 累加和重置", func() {
-			resetReRegisterState()
-			atomic.AddInt32(&notFoundCount, 1)
-			atomic.AddInt32(&notFoundCount, 1)
-			atomic.AddInt32(&notFoundCount, 1)
-			So(atomic.LoadInt32(&notFoundCount), ShouldEqual, 3)
-
-			atomic.StoreInt32(&notFoundCount, 0)
-			So(atomic.LoadInt32(&notFoundCount), ShouldEqual, 0)
-		})
-	})
-}
-
-// TestSelfRegister_SavesContext 测试 selfRegister 保存注册上下文
-func TestSelfRegister_SavesContext(t *testing.T) {
-	Convey("测试 selfRegister 保存注册上下文供重注册使用", t, func() {
-		defer resetReRegisterState()
-
-		// selfRegister 会尝试连接 Polaris server，这里只验证上下文保存逻辑
-		// 通过设置一个不可达的地址来触发连接失败
-		cfg := &Registry{
-			Name:      "polaris.limiter",
-			Namespace: "Polaris",
-		}
-		servers := []apiserver.APIServer{&mockAPIServer{protocol: "grpc", port: 8101}}
-		apiConfigs := []apiserver.Config{{Name: "grpc"}}
-
-		polarisServerAddress = "127.0.0.1:1" // 不可达地址
-		_ = selfRegister(cfg, servers, apiConfigs, "10.0.0.1")
-
-		// 验证上下文已保存
-		So(savedRegistryCfg, ShouldEqual, cfg)
-		So(savedAPIServers, ShouldResemble, servers)
-		So(savedAPIServerConfigs, ShouldResemble, apiConfigs)
-		So(savedServerAddress, ShouldEqual, "10.0.0.1")
-	})
-}
-
-// TestHeartbeat_NotFoundThreshold 测试心跳 NOT_FOUND 阈值逻辑
-func TestHeartbeat_NotFoundThreshold(t *testing.T) {
-	Convey("测试心跳 NOT_FOUND 失败计数逻辑", t, func() {
-		defer resetReRegisterState()
-
-		Convey("notFoundCount 未超过阈值时不应触发重注册", func() {
-			resetReRegisterState()
-			atomic.StoreInt32(&notFoundCount, 1)
-			So(atomic.LoadInt32(&notFoundCount), ShouldBeLessThanOrEqualTo, int32(maxHeartbeatFailCount))
-		})
-
-		Convey("notFoundCount 超过阈值时应触发重注册", func() {
-			resetReRegisterState()
-			atomic.StoreInt32(&notFoundCount, 3) // > maxHeartbeatFailCount (2)
-			So(atomic.LoadInt32(&notFoundCount), ShouldBeGreaterThan, int32(maxHeartbeatFailCount))
-		})
-
-		Convey("心跳成功后应重置 notFoundCount", func() {
-			resetReRegisterState()
-			atomic.StoreInt32(&notFoundCount, 5)
-			// 模拟心跳成功
-			atomic.StoreInt32(&notFoundCount, 0)
-			So(atomic.LoadInt32(&notFoundCount), ShouldEqual, 0)
-		})
-	})
-}
-
-// TestAsyncReRegister_NilConfig 测试 savedRegistryCfg 为 nil 时的防护
+// TestAsyncReRegister_NilConfig 测试 registryCtx 为 nil 时的防护
 func TestAsyncReRegister_NilConfig(t *testing.T) {
-	Convey("测试 asyncReRegister 在 savedRegistryCfg 为 nil 时不崩溃", t, func() {
-		defer resetReRegisterState()
-		resetReRegisterState()
+	Convey("测试 asyncReRegister 在 registryCtx 为 nil 时不崩溃", t, func() {
+		defer resetRegistrar()
+		resetRegistrar()
 
-		// savedRegistryCfg 为 nil，asyncReRegister 应安全退出
 		ctx, cancel := context.WithCancel(context.Background())
 		defer cancel()
 
-		// 直接调用，不应 panic
-		atomic.StoreInt32(&reRegistering, 1)
-		asyncReRegister(ctx)
+		// 手动占用 reRegistering 标志，模拟 triggerAsyncReRegister 刚 CAS 成功
+		reg.reRegistering.Store(1)
+		reg.asyncReRegister(ctx)
 
-		// reRegistering 应被重置为 0
-		So(atomic.LoadInt32(&reRegistering), ShouldEqual, 0)
+		// reRegistering 应被 defer 重置为 0
+		So(reg.reRegistering.Load(), ShouldEqual, int32(0))
 	})
 }
 
 // TestAsyncReRegister_ContextCancelled 测试 context 取消时退出重注册
 func TestAsyncReRegister_ContextCancelled(t *testing.T) {
 	Convey("测试 asyncReRegister 在 context 取消时安全退出", t, func() {
-		defer resetReRegisterState()
-		resetReRegisterState()
+		defer resetRegistrar()
+		resetRegistrar()
 
-		// 设置一个较大的退避计数，使 delay > 0
-		atomic.StoreInt32(&reRegisterCount, 5)
+		// 预置 registryCtx，避免首轮因 nil 直接返回
+		reg.ctx.Store(&registryCtx{cfg: &Registry{Name: "polaris.limiter"}})
+		// 设置一个较大的退避计数，使 delay > 0 以便测试 ctx 取消路径
+		reg.reRegisterCount.Store(5)
 
 		ctx, cancel := context.WithCancel(context.Background())
-		atomic.StoreInt32(&reRegistering, 1)
+		reg.reRegistering.Store(1)
 
 		done := make(chan struct{})
 		go func() {
-			asyncReRegister(ctx)
+			reg.asyncReRegister(ctx)
 			close(done)
 		}()
 
 		// 立即取消 context
 		cancel()
 
-		// 等待 asyncReRegister 退出
 		select {
 		case <-done:
-			// 正常退出
 		case <-time.After(3 * time.Second):
 			t.Fatal("asyncReRegister did not exit after context cancellation")
 		}
 
-		So(atomic.LoadInt32(&reRegistering), ShouldEqual, 0)
+		So(reg.reRegistering.Load(), ShouldEqual, int32(0))
+	})
+}
+
+// TestTriggerAsyncReRegister_CASDedup 测试连续触发只有一个 goroutine 执行重注册
+func TestTriggerAsyncReRegister_CASDedup(t *testing.T) {
+	Convey("连续触发 triggerAsyncReRegister 时，CAS 保证仅一次执行", t, func() {
+		defer resetRegistrar()
+		resetRegistrar()
+
+		reg.ctx.Store(&registryCtx{cfg: &Registry{Name: "polaris.limiter"}})
+
+		var calls atomic.Int32
+		release := make(chan struct{})
+		registerFn = func(r *registrar, cfg *Registry, servers []apiserver.APIServer,
+			apiServerConfigs []apiserver.Config, serverAddress string) error {
+			calls.Add(1)
+			<-release
+			return nil
+		}
+
+		reg.triggerAsyncReRegister(context.Background())
+		// 第二次触发应被 CAS 拦截
+		reg.triggerAsyncReRegister(context.Background())
+		reg.triggerAsyncReRegister(context.Background())
+
+		// 等待首个 goroutine 进入 registerFn
+		deadline := time.Now().Add(2 * time.Second)
+		for calls.Load() == 0 && time.Now().Before(deadline) {
+			time.Sleep(10 * time.Millisecond)
+		}
+		So(calls.Load(), ShouldEqual, int32(1))
+		So(reg.reRegistering.Load(), ShouldEqual, int32(1))
+
+		close(release)
+		// 等待重注册协程退出
+		deadline = time.Now().Add(2 * time.Second)
+		for reg.reRegistering.Load() != 0 && time.Now().Before(deadline) {
+			time.Sleep(10 * time.Millisecond)
+		}
+		So(reg.reRegistering.Load(), ShouldEqual, int32(0))
+		So(calls.Load(), ShouldEqual, int32(1))
+	})
+}
+
+// TestAsyncReRegister_SuccessResetsCounters 测试重注册成功后重置计数器
+func TestAsyncReRegister_SuccessResetsCounters(t *testing.T) {
+	Convey("重注册成功后应重置 notFoundCount 与 reRegisterCount", t, func() {
+		defer resetRegistrar()
+		resetRegistrar()
+
+		reg.ctx.Store(&registryCtx{cfg: &Registry{Name: "polaris.limiter"}})
+		reg.notFoundCount.Store(5)
+		reg.reRegisterCount.Store(0) // 首轮 delay=0 以缩短测试耗时
+		reg.reRegistering.Store(1)
+
+		registerFn = func(r *registrar, cfg *Registry, servers []apiserver.APIServer,
+			apiServerConfigs []apiserver.Config, serverAddress string) error {
+			return nil
+		}
+
+		reg.asyncReRegister(context.Background())
+
+		So(reg.notFoundCount.Load(), ShouldEqual, int32(0))
+		So(reg.reRegisterCount.Load(), ShouldEqual, int32(0))
+		So(reg.reRegistering.Load(), ShouldEqual, int32(0))
+	})
+}
+
+// TestAsyncReRegister_RetryOnFailure 测试失败后在内部循环重试直到成功
+func TestAsyncReRegister_RetryOnFailure(t *testing.T) {
+	Convey("重注册失败后应继续内部循环重试，成功后重置计数器", t, func() {
+		defer resetRegistrar()
+		resetRegistrar()
+
+		reg.ctx.Store(&registryCtx{cfg: &Registry{Name: "polaris.limiter"}})
+		reg.reRegistering.Store(1)
+
+		// 第 1 次失败 -> reRegisterCount 变为 1，下轮 delay >= serverTtl（5s）
+		// 为了避免测试耗时，通过构造 ctx 提前取消后验证计数器累加行为
+		var calls atomic.Int32
+		registerFn = func(r *registrar, cfg *Registry, servers []apiserver.APIServer,
+			apiServerConfigs []apiserver.Config, serverAddress string) error {
+			n := calls.Add(1)
+			if n == 1 {
+				return fmt.Errorf("mock failure")
+			}
+			return nil
+		}
+
+		// 使用带超时的 ctx，避免因失败退避时间过长而挂起
+		ctx, cancel := context.WithTimeout(context.Background(), 500*time.Millisecond)
+		defer cancel()
+
+		reg.asyncReRegister(ctx)
+
+		// 首轮失败会累加，然后进入 delay（约 5~10s），被 ctx 取消返回。
+		// 因此 reRegisterCount 至少为 1；calls 至少为 1 且 ≤ 2。
+		So(calls.Load(), ShouldBeGreaterThanOrEqualTo, int32(1))
+		So(calls.Load(), ShouldBeLessThanOrEqualTo, int32(2))
+		So(reg.reRegisterCount.Load(), ShouldBeGreaterThanOrEqualTo, int32(1))
+		So(reg.reRegistering.Load(), ShouldEqual, int32(0))
+	})
+}
+
+// TestHandleHeartbeatResp 测试心跳响应处理逻辑
+func TestHandleHeartbeatResp(t *testing.T) {
+	Convey("测试 handleHeartbeatResp 对响应码的处理", t, func() {
+		defer resetRegistrar()
+
+		instance := &polaris.Instance{
+			Host: &wrappers.StringValue{Value: "10.0.0.1"},
+			Port: &wrappers.UInt32Value{Value: 8101},
+		}
+
+		Convey("心跳 err 非空时返回 err", func() {
+			resetRegistrar()
+			err := reg.handleHeartbeatResp(context.Background(), instance, nil, fmt.Errorf("boom"))
+			So(err, ShouldNotBeNil)
+			So(reg.notFoundCount.Load(), ShouldEqual, int32(0))
+		})
+
+		Convey("成功响应应清零 notFoundCount", func() {
+			resetRegistrar()
+			reg.notFoundCount.Store(3)
+			resp := &polaris.Response{Code: &wrappers.UInt32Value{Value: 200000}}
+			err := reg.handleHeartbeatResp(context.Background(), instance, resp, nil)
+			So(err, ShouldBeNil)
+			So(reg.notFoundCount.Load(), ShouldEqual, int32(0))
+		})
+
+		Convey("NOT_FOUND 但未超阈值时不触发重注册", func() {
+			resetRegistrar()
+			// 阻塞 registerFn 以便观测是否被触发
+			registerFn = func(r *registrar, cfg *Registry, servers []apiserver.APIServer,
+				apiServerConfigs []apiserver.Config, serverAddress string) error {
+				return nil
+			}
+			resp := &polaris.Response{Code: &wrappers.UInt32Value{Value: notFoundResourceCode}}
+			err := reg.handleHeartbeatResp(context.Background(), instance, resp, nil)
+			So(err, ShouldNotBeNil)
+			So(reg.notFoundCount.Load(), ShouldEqual, int32(1))
+			So(reg.reRegistering.Load(), ShouldEqual, int32(0))
+		})
+
+		Convey("NOT_FOUND 且超阈值时触发异步重注册", func() {
+			resetRegistrar()
+			reg.ctx.Store(&registryCtx{cfg: &Registry{Name: "polaris.limiter"}})
+			// 预置计数让本次累加后刚好超阈值
+			reg.notFoundCount.Store(int32(maxHeartbeatFailCount))
+
+			release := make(chan struct{})
+			var called atomic.Int32
+			registerFn = func(r *registrar, cfg *Registry, servers []apiserver.APIServer,
+				apiServerConfigs []apiserver.Config, serverAddress string) error {
+				called.Add(1)
+				<-release
+				return nil
+			}
+
+			resp := &polaris.Response{Code: &wrappers.UInt32Value{Value: notFoundResourceCode}}
+			err := reg.handleHeartbeatResp(context.Background(), instance, resp, nil)
+			So(err, ShouldNotBeNil)
+
+			// 等待 goroutine 启动
+			deadline := time.Now().Add(2 * time.Second)
+			for called.Load() == 0 && time.Now().Before(deadline) {
+				time.Sleep(10 * time.Millisecond)
+			}
+			So(reg.reRegistering.Load(), ShouldEqual, int32(1))
+			So(called.Load(), ShouldEqual, int32(1))
+
+			close(release)
+			// 等待清理
+			deadline = time.Now().Add(2 * time.Second)
+			for reg.reRegistering.Load() != 0 && time.Now().Before(deadline) {
+				time.Sleep(10 * time.Millisecond)
+			}
+			So(reg.reRegistering.Load(), ShouldEqual, int32(0))
+		})
 	})
 }
 

--- a/bootstrap/registry_test.go
+++ b/bootstrap/registry_test.go
@@ -18,8 +18,11 @@
 package bootstrap
 
 import (
+	"context"
 	"os"
+	"sync/atomic"
 	"testing"
+	"time"
 
 	. "github.com/smartystreets/goconvey/convey"
 	"gopkg.in/yaml.v2"
@@ -622,6 +625,194 @@ api-servers:
 			So(config.APIServers[1].ShouldRegister(), ShouldBeTrue)
 			So(config.APIServers[1].RegisterPort, ShouldEqual, uint32(19001))
 		})
+	})
+}
+
+// resetReRegisterState 重置所有重注册相关的全局状态，用于测试隔离
+func resetReRegisterState() {
+	atomic.StoreInt32(&notFoundCount, 0)
+	atomic.StoreInt32(&reRegisterCount, 0)
+	atomic.StoreInt32(&reRegistering, 0)
+	savedRegistryCfg = nil
+	savedAPIServers = nil
+	savedAPIServerConfigs = nil
+	savedServerAddress = ""
+}
+
+// TestCalcReRegisterDelay 测试退避延迟计算逻辑
+func TestCalcReRegisterDelay(t *testing.T) {
+	Convey("测试 calcReRegisterDelay 退避延迟计算", t, func() {
+		Convey("count=0 时应立即执行（delay=0）", func() {
+			delay := calcReRegisterDelay(0)
+			So(delay, ShouldEqual, 0)
+		})
+
+		Convey("count<0 时应立即执行（delay=0）", func() {
+			delay := calcReRegisterDelay(-1)
+			So(delay, ShouldEqual, 0)
+		})
+
+		Convey("count=1 时 delay = serverTtl * 2^0 + jitter = serverTtl + jitter", func() {
+			delay := calcReRegisterDelay(1)
+			// base = 5s * 2^0 = 5s, jitter in [0, 5s)
+			// delay in [5s, 10s)
+			So(delay, ShouldBeGreaterThanOrEqualTo, serverTtl)
+			So(delay, ShouldBeLessThan, 2*serverTtl)
+		})
+
+		Convey("count=2 时 delay = serverTtl * 2^1 + jitter = 10s + jitter", func() {
+			delay := calcReRegisterDelay(2)
+			// base = 5s * 2^1 = 10s, jitter in [0, 5s)
+			// delay in [10s, 15s)
+			So(delay, ShouldBeGreaterThanOrEqualTo, 2*serverTtl)
+			So(delay, ShouldBeLessThan, 3*serverTtl)
+		})
+
+		Convey("大 count 值时 delay 应不超过 maxReRegisterDelay", func() {
+			delay := calcReRegisterDelay(100)
+			So(delay, ShouldBeLessThanOrEqualTo, maxReRegisterDelay)
+		})
+	})
+}
+
+// TestReRegisterState_AtomicFlags 测试重注册状态标志的原子操作
+func TestReRegisterState_AtomicFlags(t *testing.T) {
+	Convey("测试重注册状态标志", t, func() {
+		defer resetReRegisterState()
+
+		Convey("初始状态 reRegistering 应为 0", func() {
+			resetReRegisterState()
+			So(atomic.LoadInt32(&reRegistering), ShouldEqual, 0)
+		})
+
+		Convey("CAS 设置 reRegistering 应成功", func() {
+			resetReRegisterState()
+			ok := atomic.CompareAndSwapInt32(&reRegistering, 0, 1)
+			So(ok, ShouldBeTrue)
+			So(atomic.LoadInt32(&reRegistering), ShouldEqual, 1)
+		})
+
+		Convey("reRegistering 已为 1 时 CAS 应失败", func() {
+			resetReRegisterState()
+			atomic.StoreInt32(&reRegistering, 1)
+			ok := atomic.CompareAndSwapInt32(&reRegistering, 0, 1)
+			So(ok, ShouldBeFalse)
+		})
+
+		Convey("notFoundCount 累加和重置", func() {
+			resetReRegisterState()
+			atomic.AddInt32(&notFoundCount, 1)
+			atomic.AddInt32(&notFoundCount, 1)
+			atomic.AddInt32(&notFoundCount, 1)
+			So(atomic.LoadInt32(&notFoundCount), ShouldEqual, 3)
+
+			atomic.StoreInt32(&notFoundCount, 0)
+			So(atomic.LoadInt32(&notFoundCount), ShouldEqual, 0)
+		})
+	})
+}
+
+// TestSelfRegister_SavesContext 测试 selfRegister 保存注册上下文
+func TestSelfRegister_SavesContext(t *testing.T) {
+	Convey("测试 selfRegister 保存注册上下文供重注册使用", t, func() {
+		defer resetReRegisterState()
+
+		// selfRegister 会尝试连接 Polaris server，这里只验证上下文保存逻辑
+		// 通过设置一个不可达的地址来触发连接失败
+		cfg := &Registry{
+			Name:      "polaris.limiter",
+			Namespace: "Polaris",
+		}
+		servers := []apiserver.APIServer{&mockAPIServer{protocol: "grpc", port: 8101}}
+		apiConfigs := []apiserver.Config{{Name: "grpc"}}
+
+		polarisServerAddress = "127.0.0.1:1" // 不可达地址
+		_ = selfRegister(cfg, servers, apiConfigs, "10.0.0.1")
+
+		// 验证上下文已保存
+		So(savedRegistryCfg, ShouldEqual, cfg)
+		So(savedAPIServers, ShouldResemble, servers)
+		So(savedAPIServerConfigs, ShouldResemble, apiConfigs)
+		So(savedServerAddress, ShouldEqual, "10.0.0.1")
+	})
+}
+
+// TestHeartbeat_NotFoundThreshold 测试心跳 NOT_FOUND 阈值逻辑
+func TestHeartbeat_NotFoundThreshold(t *testing.T) {
+	Convey("测试心跳 NOT_FOUND 失败计数逻辑", t, func() {
+		defer resetReRegisterState()
+
+		Convey("notFoundCount 未超过阈值时不应触发重注册", func() {
+			resetReRegisterState()
+			atomic.StoreInt32(&notFoundCount, 1)
+			So(atomic.LoadInt32(&notFoundCount), ShouldBeLessThanOrEqualTo, int32(maxHeartbeatFailCount))
+		})
+
+		Convey("notFoundCount 超过阈值时应触发重注册", func() {
+			resetReRegisterState()
+			atomic.StoreInt32(&notFoundCount, 3) // > maxHeartbeatFailCount (2)
+			So(atomic.LoadInt32(&notFoundCount), ShouldBeGreaterThan, int32(maxHeartbeatFailCount))
+		})
+
+		Convey("心跳成功后应重置 notFoundCount", func() {
+			resetReRegisterState()
+			atomic.StoreInt32(&notFoundCount, 5)
+			// 模拟心跳成功
+			atomic.StoreInt32(&notFoundCount, 0)
+			So(atomic.LoadInt32(&notFoundCount), ShouldEqual, 0)
+		})
+	})
+}
+
+// TestAsyncReRegister_NilConfig 测试 savedRegistryCfg 为 nil 时的防护
+func TestAsyncReRegister_NilConfig(t *testing.T) {
+	Convey("测试 asyncReRegister 在 savedRegistryCfg 为 nil 时不崩溃", t, func() {
+		defer resetReRegisterState()
+		resetReRegisterState()
+
+		// savedRegistryCfg 为 nil，asyncReRegister 应安全退出
+		ctx, cancel := context.WithCancel(context.Background())
+		defer cancel()
+
+		// 直接调用，不应 panic
+		atomic.StoreInt32(&reRegistering, 1)
+		asyncReRegister(ctx)
+
+		// reRegistering 应被重置为 0
+		So(atomic.LoadInt32(&reRegistering), ShouldEqual, 0)
+	})
+}
+
+// TestAsyncReRegister_ContextCancelled 测试 context 取消时退出重注册
+func TestAsyncReRegister_ContextCancelled(t *testing.T) {
+	Convey("测试 asyncReRegister 在 context 取消时安全退出", t, func() {
+		defer resetReRegisterState()
+		resetReRegisterState()
+
+		// 设置一个较大的退避计数，使 delay > 0
+		atomic.StoreInt32(&reRegisterCount, 5)
+
+		ctx, cancel := context.WithCancel(context.Background())
+		atomic.StoreInt32(&reRegistering, 1)
+
+		done := make(chan struct{})
+		go func() {
+			asyncReRegister(ctx)
+			close(done)
+		}()
+
+		// 立即取消 context
+		cancel()
+
+		// 等待 asyncReRegister 退出
+		select {
+		case <-done:
+			// 正常退出
+		case <-time.After(3 * time.Second):
+			t.Fatal("asyncReRegister did not exit after context cancellation")
+		}
+
+		So(atomic.LoadInt32(&reRegistering), ShouldEqual, 0)
 	})
 }
 

--- a/bootstrap/registry_test.go
+++ b/bootstrap/registry_test.go
@@ -634,10 +634,7 @@ api-servers:
 // resetRegistrar 重置 registrar 单例及 registerFn 注入点，供测试隔离使用。
 func resetRegistrar() {
 	reg = &registrar{}
-	registerFn = func(r *registrar, cfg *Registry, servers []apiserver.APIServer,
-		apiServerConfigs []apiserver.Config, serverAddress string) error {
-		return r.doSelfRegister(cfg, servers, apiServerConfigs, serverAddress)
-	}
+	registerFn = func(r *registrar) error { return r.doSelfRegister() }
 }
 
 // TestCalcReRegisterDelay 测试退避延迟计算逻辑
@@ -746,8 +743,7 @@ func TestTriggerAsyncReRegister_CASDedup(t *testing.T) {
 
 		var calls atomic.Int32
 		release := make(chan struct{})
-		registerFn = func(r *registrar, cfg *Registry, servers []apiserver.APIServer,
-			apiServerConfigs []apiserver.Config, serverAddress string) error {
+		registerFn = func(r *registrar) error {
 			calls.Add(1)
 			<-release
 			return nil
@@ -788,10 +784,7 @@ func TestAsyncReRegister_SuccessResetsCounters(t *testing.T) {
 		reg.reRegisterCount.Store(0) // 首轮 delay=0 以缩短测试耗时
 		reg.reRegistering.Store(1)
 
-		registerFn = func(r *registrar, cfg *Registry, servers []apiserver.APIServer,
-			apiServerConfigs []apiserver.Config, serverAddress string) error {
-			return nil
-		}
+		registerFn = func(r *registrar) error { return nil }
 
 		reg.asyncReRegister(context.Background())
 
@@ -801,38 +794,31 @@ func TestAsyncReRegister_SuccessResetsCounters(t *testing.T) {
 	})
 }
 
-// TestAsyncReRegister_RetryOnFailure 测试失败后在内部循环重试直到成功
+// TestAsyncReRegister_RetryOnFailure 测试失败后累加计数、ctx 取消时从退避中退出
 func TestAsyncReRegister_RetryOnFailure(t *testing.T) {
-	Convey("重注册失败后应继续内部循环重试，成功后重置计数器", t, func() {
+	Convey("重注册首次失败应累加 reRegisterCount，ctx 取消后退出", t, func() {
 		defer resetRegistrar()
 		resetRegistrar()
 
 		reg.ctx.Store(&registryCtx{cfg: &Registry{Name: "polaris.limiter"}})
 		reg.reRegistering.Store(1)
 
-		// 第 1 次失败 -> reRegisterCount 变为 1，下轮 delay >= serverTtl（5s）
-		// 为了避免测试耗时，通过构造 ctx 提前取消后验证计数器累加行为
 		var calls atomic.Int32
-		registerFn = func(r *registrar, cfg *Registry, servers []apiserver.APIServer,
-			apiServerConfigs []apiserver.Config, serverAddress string) error {
-			n := calls.Add(1)
-			if n == 1 {
-				return fmt.Errorf("mock failure")
-			}
-			return nil
+		registerFn = func(r *registrar) error {
+			calls.Add(1)
+			return fmt.Errorf("mock failure")
 		}
 
-		// 使用带超时的 ctx，避免因失败退避时间过长而挂起
-		ctx, cancel := context.WithTimeout(context.Background(), 500*time.Millisecond)
+		// ctx 提前取消：首轮 delay=0 会立即调用 registerFn 失败，
+		// 累加计数后进入下一轮 delay ≥ serverTtl，ctx 已取消，select 立刻返回。
+		ctx, cancel := context.WithTimeout(context.Background(), 100*time.Millisecond)
 		defer cancel()
 
 		reg.asyncReRegister(ctx)
 
-		// 首轮失败会累加，然后进入 delay（约 5~10s），被 ctx 取消返回。
-		// 因此 reRegisterCount 至少为 1；calls 至少为 1 且 ≤ 2。
-		So(calls.Load(), ShouldBeGreaterThanOrEqualTo, int32(1))
-		So(calls.Load(), ShouldBeLessThanOrEqualTo, int32(2))
-		So(reg.reRegisterCount.Load(), ShouldBeGreaterThanOrEqualTo, int32(1))
+		// 首轮 delay=0 直接进入 registerFn，失败；第二轮 delay 被 ctx 取消，不会再次进入。
+		So(calls.Load(), ShouldEqual, int32(1))
+		So(reg.reRegisterCount.Load(), ShouldEqual, int32(1))
 		So(reg.reRegistering.Load(), ShouldEqual, int32(0))
 	})
 }
@@ -865,11 +851,7 @@ func TestHandleHeartbeatResp(t *testing.T) {
 
 		Convey("NOT_FOUND 但未超阈值时不触发重注册", func() {
 			resetRegistrar()
-			// 阻塞 registerFn 以便观测是否被触发
-			registerFn = func(r *registrar, cfg *Registry, servers []apiserver.APIServer,
-				apiServerConfigs []apiserver.Config, serverAddress string) error {
-				return nil
-			}
+			registerFn = func(r *registrar) error { return nil }
 			resp := &polaris.Response{Code: &wrappers.UInt32Value{Value: notFoundResourceCode}}
 			err := reg.handleHeartbeatResp(context.Background(), instance, resp, nil)
 			So(err, ShouldNotBeNil)
@@ -885,8 +867,7 @@ func TestHandleHeartbeatResp(t *testing.T) {
 
 			release := make(chan struct{})
 			var called atomic.Int32
-			registerFn = func(r *registrar, cfg *Registry, servers []apiserver.APIServer,
-				apiServerConfigs []apiserver.Config, serverAddress string) error {
+			registerFn = func(r *registrar) error {
 				called.Add(1)
 				<-release
 				return nil


### PR DESCRIPTION
## Summary

- 当 limiter 实例在 Polaris 中被手动删除后，心跳检测到 `NotFoundResource`（400202）响应，自动触发异步重注册恢复服务
- 采用指数退避 + 随机抖动策略（上限 60s），与 polaris-go / polaris-java SDK 行为一致
- 使用 CAS 标志防止并发重注册，修复 `selfRegister` 吞掉单个实例注册错误的 bug

## Changes

- `bootstrap/registry.go`：心跳中检测 NOT_FOUND 响应码，连续失败 > 2 次触发 `asyncReRegister`；新增 `triggerAsyncReRegister`、`asyncReRegister`、`calcReRegisterDelay` 函数；`selfRegister` 保存注册上下文供重注册复用
- `bootstrap/registry_test.go`：新增 6 个单元测试覆盖退避计算、原子状态、上下文保存、阈值逻辑、nil 防护、context 取消

## Test plan

- [x] `go build ./...` 编译通过
- [x] `go test ./bootstrap/` 全部 18 个测试通过
- [x] `go test $(go list ./... | grep -v '/test/')` 全部非集成测试通过
- [ ] 部署到测试环境，手动删除 Polaris 中的实例，验证自动恢复

🤖 Generated with [Claude Code](https://claude.com/claude-code)