### PR TITLE
fix(deploy): 容器入口使用 exec 让 polaris-limiter 成为 PID 1 以支持优雅反注册

### DIFF
--- a/deploy/kubernetes/start-limiter.sh
+++ b/deploy/kubernetes/start-limiter.sh
@@ -23,4 +23,8 @@ export MY_ID="${LIMITER_MY_ID}"
 envsubst </root/polaris-limiter.yaml.example >/root/polaris-limiter.yaml
 
 # 运行 polaris-limiter
-./polaris-limiter start
+# 使用 exec 让 polaris-limiter 替换当前 bash 进程成为 PID 1，
+# 这样 K8s 删除 Pod 时下发的 SIGTERM 能直达 polaris-limiter，
+# 触发 runMainLoop → stopServers → selfDeregister 完成优雅反注册；
+# 否则 bash 作为 PID 1 不会转发信号给子进程，导致反注册失败,实例残留为异常状态。
+exec ./polaris-limiter start


### PR DESCRIPTION
start-limiter.sh 以 bash 作为 PID 1 前台启动 polaris-limiter，bash 不会把 K8s 删除 Pod 时下发的 SIGTERM 转发给子进程，导致 runMainLoop
无法触发 stopServers → selfDeregister，Pod 终止时实例残留为异常状态。

改用 exec 替换当前 bash 进程，使 polaris-limiter 占据 PID 1，SIGTERM 直达信号处理逻辑完成优雅反注册。
